### PR TITLE
Concatenate sublocality address components

### DIFF
--- a/lib/teslamate/locations/geocoder.ex
+++ b/lib/teslamate/locations/geocoder.ex
@@ -361,11 +361,16 @@ defmodule TeslaMate.Locations.Geocoder do
     country = get_component.(["country"])
     postcode = get_component.(["postal_code"])
     
-    # 获取地点名称 - 从 address_components 第一个元素的 long_name 获取
-    name = case components do
-      [first_component | _] -> first_component["long_name"]
-      [] -> nil
-    end
+    # 获取地点名称 - 从包含 sublocality 类型的组件中倒序拼接
+    name = components
+    |> Enum.filter(fn component ->
+      types = component["types"] || []
+      "sublocality" in types
+    end)
+    |> Enum.map(fn component -> component["long_name"] end)
+    |> Enum.reverse()
+    |> Enum.join("")
+    |> then(fn result -> if result == "", do: nil, else: result end)
     
     %{
       display_name: first_result["formatted_address"] || "Unknown",


### PR DESCRIPTION
Improve Google Geocoder location name extraction by concatenating sublocality components in reverse order.

The previous logic of taking only the `long_name` of the first address component often resulted in incomplete or inaccurate location names, especially for addresses with complex sublocality structures (e.g., Japanese addresses). This change ensures a more meaningful and accurate location name is generated by combining relevant sublocality information.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab9a72f8-699e-424f-beff-5e9ef3589325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab9a72f8-699e-424f-beff-5e9ef3589325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

