### PR TITLE
Fix teslamateapi mqtt message reception bug

### DIFF
--- a/lib/teslamate/api.ex
+++ b/lib/teslamate/api.ex
@@ -4,7 +4,7 @@ defmodule TeslaMate.Api do
   require Logger
 
   alias TeslaMate.Auth.Tokens
-  alias TeslaMate.{Vehicles, Convert}
+  alias TeslaMate.{Vehicles, Convert, Mqtt}
   alias TeslaApi.Auth
 
   alias Finch.Response
@@ -149,6 +149,7 @@ defmodule TeslaMate.Api do
         true = insert_auth(state.name, auth)
         :ok = call(state.deps.auth, :save, [auth])
         :ok = call(state.deps.vehicles, :restart)
+        :ok = Mqtt.restart_pubsub()
         {:ok, state} = schedule_refresh(auth, state)
         :ok = :fuse.reset(fuse_name(state.name))
 

--- a/lib/teslamate/mqtt.ex
+++ b/lib/teslamate/mqtt.ex
@@ -1,12 +1,32 @@
 defmodule TeslaMate.Mqtt do
   use Supervisor
 
+  require Logger
+
   alias __MODULE__.{Publisher, PubSub, Handler}
 
   # API
 
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def restart_pubsub do
+    case Process.whereis(__MODULE__) do
+      nil ->
+        :ok
+
+      _pid ->
+        Logger.info("Restarting MQTT PubSub ...")
+
+        :ok = Supervisor.terminate_child(__MODULE__, PubSub)
+
+        case Supervisor.restart_child(__MODULE__, PubSub) do
+          {:ok, _pid} -> :ok
+          {:ok, _pid, _info} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+    end
   end
 
   @impl true


### PR DESCRIPTION
Restart MQTT PubSub after vehicle login to ensure `VehicleSubscriber` processes are correctly initialized.

The `TeslaMate.Mqtt.PubSub` supervisor initializes `VehicleSubscriber` processes based on `Vehicles.list()` at startup. If a user hasn't logged in yet, `Vehicles.list()` returns an empty list, leading to no `VehicleSubscriber` processes being created. When a user subsequently logs in, only `TeslaMate.Vehicles` is restarted, not `TeslaMate.Mqtt.PubSub`. This prevents vehicle data from being published to MQTT. Restarting `TeslaMate.Mqtt.PubSub` after successful login ensures that `VehicleSubscriber` processes are correctly initialized with the newly available vehicle data.

---
<a href="https://cursor.com/background-agent?bcId=bc-5295abb3-1933-48e5-8551-bd31fe87e21a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5295abb3-1933-48e5-8551-bd31fe87e21a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

